### PR TITLE
Update to ash 0.33

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,7 @@ name = "vk_sync"
 path = "src/lib.rs"
 
 [dependencies]
-# ash = { version = "0.29", optional = true }
-ash = {git = "https://github.com/MaikKlein/ash", optional = true }
-
+ash = { version = "0.33", optional = true }
 
 [features]
 default = ["ash_bind"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,9 @@ name = "vk_sync"
 path = "src/lib.rs"
 
 [dependencies]
-ash = { version = "0.29", optional = true }
+# ash = { version = "0.29", optional = true }
+ash = {git = "https://github.com/MaikKlein/ash", optional = true }
+
 
 [features]
 default = ["ash_bind"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,23 +22,5 @@ travis-ci = { repository = "gwihlidal/vk-sync-rs" }
 appveyor = { repository = "gwihlidal/vk-sync-rs" }
 maintenance = { status = "actively-developed" }
 
-[lib]
-name = "vk_sync"
-path = "src/lib.rs"
-
 [dependencies]
-ash = { version = "0.33", optional = true }
-
-[features]
-default = ["ash_bind"]
-ash_bind = ["ash"]
-
-[profile.release]
-lto = true
-opt-level = 3
-codegen-units = 1
-
-[workspace]
-members = [
-    "./",
-]
+ash = "0.33"

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -7,20 +7,20 @@ use ash;
 /// barriers to be passed to `vkCmdPipelineBarrier`.
 /// `command_buffer` is passed unmodified to `vkCmdPipelineBarrier`.
 pub fn pipeline_barrier(
-	device: &ash::vk::DeviceFnV1_0,
-	command_buffer: ash::vk::CommandBuffer,
+	device: &ash::Device,
+	command_buffer: vk::CommandBuffer,
 	global_barrier: Option<GlobalBarrier>,
 	buffer_barriers: &[BufferBarrier],
 	image_barriers: &[ImageBarrier],
 ) {
-	let mut src_stage_mask = ash::vk::PipelineStageFlags::TOP_OF_PIPE;
-	let mut dst_stage_mask = ash::vk::PipelineStageFlags::BOTTOM_OF_PIPE;
+	let mut src_stage_mask = vk::PipelineStageFlags::TOP_OF_PIPE;
+	let mut dst_stage_mask = vk::PipelineStageFlags::BOTTOM_OF_PIPE;
 
 	// TODO: Optimize out the Vec heap allocations
-	let mut vk_memory_barriers: Vec<ash::vk::MemoryBarrier> = Vec::with_capacity(1);
-	let mut vk_buffer_barriers: Vec<ash::vk::BufferMemoryBarrier> =
+	let mut vk_memory_barriers: Vec<vk::MemoryBarrier> = Vec::with_capacity(1);
+	let mut vk_buffer_barriers: Vec<vk::BufferMemoryBarrier> =
 		Vec::with_capacity(buffer_barriers.len());
-	let mut vk_image_barriers: Vec<ash::vk::ImageMemoryBarrier> =
+	let mut vk_image_barriers: Vec<vk::ImageMemoryBarrier> =
 		Vec::with_capacity(image_barriers.len());
 
 	// Global memory barrier
@@ -52,13 +52,10 @@ pub fn pipeline_barrier(
 			command_buffer,
 			src_stage_mask,
 			dst_stage_mask,
-			ash::vk::DependencyFlags::empty(),
-			vk_memory_barriers.len() as u32,
-			vk_memory_barriers.as_ptr(),
-			vk_buffer_barriers.len() as u32,
-			vk_buffer_barriers.as_ptr(),
-			vk_image_barriers.len() as u32,
-			vk_image_barriers.as_ptr(),
+			vk::DependencyFlags::empty(),
+			&vk_memory_barriers,
+			&vk_buffer_barriers,
+			&vk_image_barriers,
 		);
 	}
 }
@@ -67,12 +64,12 @@ pub fn pipeline_barrier(
 /// Sets an event when the accesses defined by `previous_accesses` are completed.
 /// `command_buffer` and `event` are passed unmodified to `vkCmdSetEvent`.
 pub fn set_event(
-	device: &ash::vk::DeviceFnV1_0,
-	command_buffer: ash::vk::CommandBuffer,
-	event: ash::vk::Event,
+	device: &ash::Device,
+	command_buffer: vk::CommandBuffer,
+	event: vk::Event,
 	previous_accesses: &[AccessType],
 ) {
-	let mut stage_mask = ash::vk::PipelineStageFlags::TOP_OF_PIPE;
+	let mut stage_mask = vk::PipelineStageFlags::TOP_OF_PIPE;
 	for previous_access in previous_accesses {
 		let previous_info = get_access_info(*previous_access);
 		stage_mask |= previous_info.stage_mask;
@@ -87,12 +84,12 @@ pub fn set_event(
 /// Resets an event when the accesses defined by `previous_accesses` are completed.
 /// `command_buffer` and `event` are passed unmodified to `vkCmdResetEvent`.
 pub fn reset_event(
-	device: &ash::vk::DeviceFnV1_0,
-	command_buffer: ash::vk::CommandBuffer,
-	event: ash::vk::Event,
+	device: &ash::Device,
+	command_buffer: vk::CommandBuffer,
+	event: vk::Event,
 	previous_accesses: &[AccessType],
 ) {
-	let mut stage_mask = ash::vk::PipelineStageFlags::TOP_OF_PIPE;
+	let mut stage_mask = vk::PipelineStageFlags::TOP_OF_PIPE;
 	for previous_access in previous_accesses {
 		let previous_info = get_access_info(*previous_access);
 		stage_mask |= previous_info.stage_mask;
@@ -110,21 +107,21 @@ pub fn reset_event(
 ///
 /// `commandBuffer` and `events` are passed unmodified to `vkCmdWaitEvents`.
 pub fn wait_events(
-	device: &ash::vk::DeviceFnV1_0,
-	command_buffer: ash::vk::CommandBuffer,
-	events: &[ash::vk::Event],
+	device: &ash::Device,
+	command_buffer: vk::CommandBuffer,
+	events: &[vk::Event],
 	global_barrier: Option<GlobalBarrier>,
 	buffer_barriers: &[BufferBarrier],
 	image_barriers: &[ImageBarrier],
 ) {
-	let mut src_stage_mask = ash::vk::PipelineStageFlags::TOP_OF_PIPE;
-	let mut dst_stage_mask = ash::vk::PipelineStageFlags::BOTTOM_OF_PIPE;
+	let mut src_stage_mask = vk::PipelineStageFlags::TOP_OF_PIPE;
+	let mut dst_stage_mask = vk::PipelineStageFlags::BOTTOM_OF_PIPE;
 
 	// TODO: Optimize out the Vec heap allocations
-	let mut vk_memory_barriers: Vec<ash::vk::MemoryBarrier> = Vec::with_capacity(1);
-	let mut vk_buffer_barriers: Vec<ash::vk::BufferMemoryBarrier> =
+	let mut vk_memory_barriers: Vec<vk::MemoryBarrier> = Vec::with_capacity(1);
+	let mut vk_buffer_barriers: Vec<vk::BufferMemoryBarrier> =
 		Vec::with_capacity(buffer_barriers.len());
-	let mut vk_image_barriers: Vec<ash::vk::ImageMemoryBarrier> =
+	let mut vk_image_barriers: Vec<vk::ImageMemoryBarrier> =
 		Vec::with_capacity(image_barriers.len());
 
 	// Global memory barrier
@@ -154,16 +151,12 @@ pub fn wait_events(
 	unsafe {
 		device.cmd_wait_events(
 			command_buffer,
-			events.len() as u32,
-			events.as_ptr(),
+			&events,
 			src_stage_mask,
 			dst_stage_mask,
-			vk_memory_barriers.len() as u32,
-			vk_memory_barriers.as_ptr(),
-			vk_buffer_barriers.len() as u32,
-			vk_buffer_barriers.as_ptr(),
-			vk_image_barriers.len() as u32,
-			vk_image_barriers.as_ptr(),
+			&vk_memory_barriers,
+			&vk_buffer_barriers,
+			&vk_image_barriers,
 		);
 	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,11 +13,7 @@
 //! Use of other synchronization mechanisms such as semaphores, fences and render
 //! passes are not addressed in this library at present.
 
-extern crate ash;
-
-pub type BufferType = ash::vk::Buffer;
-pub type ImageType = ash::vk::Image;
-pub type ImageSubresourceRangeType = ash::vk::ImageSubresourceRange;
+use ash::vk;
 
 pub mod cmd;
 
@@ -239,7 +235,7 @@ pub struct BufferBarrier<'a> {
 	pub next_accesses: &'a [AccessType],
 	pub src_queue_family_index: u32,
 	pub dst_queue_family_index: u32,
-	pub buffer: BufferType,
+	pub buffer: vk::Buffer,
 	pub offset: usize,
 	pub size: usize,
 }
@@ -279,8 +275,8 @@ pub struct ImageBarrier<'a> {
 	pub discard_contents: bool,
 	pub src_queue_family_index: u32,
 	pub dst_queue_family_index: u32,
-	pub image: ImageType,
-	pub range: ImageSubresourceRangeType,
+	pub image: vk::Image,
+	pub range: vk::ImageSubresourceRange,
 }
 
 /// Mapping function that translates a global barrier into a set of source and
@@ -289,14 +285,14 @@ pub struct ImageBarrier<'a> {
 pub fn get_memory_barrier(
 	barrier: &GlobalBarrier,
 ) -> (
-	ash::vk::PipelineStageFlags,
-	ash::vk::PipelineStageFlags,
-	ash::vk::MemoryBarrier,
+	vk::PipelineStageFlags,
+	vk::PipelineStageFlags,
+	vk::MemoryBarrier,
 ) {
-	let mut src_stages = ash::vk::PipelineStageFlags::empty();
-	let mut dst_stages = ash::vk::PipelineStageFlags::empty();
+	let mut src_stages = vk::PipelineStageFlags::empty();
+	let mut dst_stages = vk::PipelineStageFlags::empty();
 
-	let mut memory_barrier = ash::vk::MemoryBarrier::default();
+	let mut memory_barrier = vk::MemoryBarrier::default();
 
 	for previous_access in barrier.previous_accesses {
 		let previous_info = get_access_info(*previous_access);
@@ -317,18 +313,18 @@ pub fn get_memory_barrier(
 		// Add visibility operations as necessary.
 		// If the src access mask, this is a WAR hazard (or for some reason a "RAR"),
 		// so the dst access mask can be safely zeroed as these don't need visibility.
-		if memory_barrier.src_access_mask != ash::vk::AccessFlags::empty() {
+		if memory_barrier.src_access_mask != vk::AccessFlags::empty() {
 			memory_barrier.dst_access_mask |= next_info.access_mask;
 		}
 	}
 
 	// Ensure that the stage masks are valid if no stages were determined
-	if src_stages == ash::vk::PipelineStageFlags::empty() {
-		src_stages = ash::vk::PipelineStageFlags::TOP_OF_PIPE;
+	if src_stages == vk::PipelineStageFlags::empty() {
+		src_stages = vk::PipelineStageFlags::TOP_OF_PIPE;
 	}
 
-	if dst_stages == ash::vk::PipelineStageFlags::empty() {
-		dst_stages = ash::vk::PipelineStageFlags::BOTTOM_OF_PIPE;
+	if dst_stages == vk::PipelineStageFlags::empty() {
+		dst_stages = vk::PipelineStageFlags::BOTTOM_OF_PIPE;
 	}
 
 	(src_stages, dst_stages, memory_barrier)
@@ -340,14 +336,14 @@ pub fn get_memory_barrier(
 pub fn get_buffer_memory_barrier(
 	barrier: &BufferBarrier,
 ) -> (
-	ash::vk::PipelineStageFlags,
-	ash::vk::PipelineStageFlags,
-	ash::vk::BufferMemoryBarrier,
+	vk::PipelineStageFlags,
+	vk::PipelineStageFlags,
+	vk::BufferMemoryBarrier,
 ) {
-	let mut src_stages = ash::vk::PipelineStageFlags::empty();
-	let mut dst_stages = ash::vk::PipelineStageFlags::empty();
+	let mut src_stages = vk::PipelineStageFlags::empty();
+	let mut dst_stages = vk::PipelineStageFlags::empty();
 
-	let mut buffer_barrier = ash::vk::BufferMemoryBarrier {
+	let mut buffer_barrier = vk::BufferMemoryBarrier {
 		src_queue_family_index: barrier.src_queue_family_index,
 		dst_queue_family_index: barrier.dst_queue_family_index,
 		buffer: barrier.buffer,
@@ -375,18 +371,18 @@ pub fn get_buffer_memory_barrier(
 		// Add visibility operations as necessary.
 		// If the src access mask, this is a WAR hazard (or for some reason a "RAR"),
 		// so the dst access mask can be safely zeroed as these don't need visibility.
-		if buffer_barrier.src_access_mask != ash::vk::AccessFlags::empty() {
+		if buffer_barrier.src_access_mask != vk::AccessFlags::empty() {
 			buffer_barrier.dst_access_mask |= next_info.access_mask;
 		}
 	}
 
 	// Ensure that the stage masks are valid if no stages were determined
-	if src_stages == ash::vk::PipelineStageFlags::empty() {
-		src_stages = ash::vk::PipelineStageFlags::TOP_OF_PIPE;
+	if src_stages == vk::PipelineStageFlags::empty() {
+		src_stages = vk::PipelineStageFlags::TOP_OF_PIPE;
 	}
 
-	if dst_stages == ash::vk::PipelineStageFlags::empty() {
-		dst_stages = ash::vk::PipelineStageFlags::BOTTOM_OF_PIPE;
+	if dst_stages == vk::PipelineStageFlags::empty() {
+		dst_stages = vk::PipelineStageFlags::BOTTOM_OF_PIPE;
 	}
 
 	(src_stages, dst_stages, buffer_barrier)
@@ -398,14 +394,14 @@ pub fn get_buffer_memory_barrier(
 pub fn get_image_memory_barrier(
 	barrier: &ImageBarrier,
 ) -> (
-	ash::vk::PipelineStageFlags,
-	ash::vk::PipelineStageFlags,
-	ash::vk::ImageMemoryBarrier,
+	vk::PipelineStageFlags,
+	vk::PipelineStageFlags,
+	vk::ImageMemoryBarrier,
 ) {
-	let mut src_stages = ash::vk::PipelineStageFlags::empty();
-	let mut dst_stages = ash::vk::PipelineStageFlags::empty();
+	let mut src_stages = vk::PipelineStageFlags::empty();
+	let mut dst_stages = vk::PipelineStageFlags::empty();
 
-	let mut image_barrier = ash::vk::ImageMemoryBarrier {
+	let mut image_barrier = vk::ImageMemoryBarrier {
 		src_queue_family_index: barrier.src_queue_family_index,
 		dst_queue_family_index: barrier.dst_queue_family_index,
 		image: barrier.image,
@@ -424,20 +420,20 @@ pub fn get_image_memory_barrier(
 		}
 
 		if barrier.discard_contents {
-			image_barrier.old_layout = ash::vk::ImageLayout::UNDEFINED;
+			image_barrier.old_layout = vk::ImageLayout::UNDEFINED;
 		} else {
 			let layout = match barrier.previous_layout {
 				ImageLayout::General => {
 					if *previous_access == AccessType::Present {
-						ash::vk::ImageLayout::PRESENT_SRC_KHR
+						vk::ImageLayout::PRESENT_SRC_KHR
 					} else {
-						ash::vk::ImageLayout::GENERAL
+						vk::ImageLayout::GENERAL
 					}
 				}
 				ImageLayout::Optimal => previous_info.image_layout,
 				ImageLayout::GeneralAndPresentation => {
 					unimplemented!()
-					// TODO: layout = ash::vk::ImageLayout::VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR
+					// TODO: layout = vk::ImageLayout::VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR
 				}
 			};
 
@@ -453,22 +449,22 @@ pub fn get_image_memory_barrier(
 		// Add visibility operations as necessary.
 		// If the src access mask, this is a WAR hazard (or for some reason a "RAR"),
 		// so the dst access mask can be safely zeroed as these don't need visibility.
-		if image_barrier.src_access_mask != ash::vk::AccessFlags::empty() {
+		if image_barrier.src_access_mask != vk::AccessFlags::empty() {
 			image_barrier.dst_access_mask |= next_info.access_mask;
 		}
 
 		let layout = match barrier.next_layout {
 			ImageLayout::General => {
 				if *next_access == AccessType::Present {
-					ash::vk::ImageLayout::PRESENT_SRC_KHR
+					vk::ImageLayout::PRESENT_SRC_KHR
 				} else {
-					ash::vk::ImageLayout::GENERAL
+					vk::ImageLayout::GENERAL
 				}
 			}
 			ImageLayout::Optimal => next_info.image_layout,
 			ImageLayout::GeneralAndPresentation => {
 				unimplemented!()
-				// TODO: layout = ash::vk::ImageLayout::VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR
+				// TODO: layout = vk::ImageLayout::VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR
 			}
 		};
 
@@ -476,284 +472,283 @@ pub fn get_image_memory_barrier(
 	}
 
 	// Ensure that the stage masks are valid if no stages were determined
-	if src_stages == ash::vk::PipelineStageFlags::empty() {
-		src_stages = ash::vk::PipelineStageFlags::TOP_OF_PIPE;
+	if src_stages == vk::PipelineStageFlags::empty() {
+		src_stages = vk::PipelineStageFlags::TOP_OF_PIPE;
 	}
 
-	if dst_stages == ash::vk::PipelineStageFlags::empty() {
-		dst_stages = ash::vk::PipelineStageFlags::BOTTOM_OF_PIPE;
+	if dst_stages == vk::PipelineStageFlags::empty() {
+		dst_stages = vk::PipelineStageFlags::BOTTOM_OF_PIPE;
 	}
 
 	(src_stages, dst_stages, image_barrier)
 }
 
 pub(crate) struct AccessInfo {
-	pub(crate) stage_mask: ash::vk::PipelineStageFlags,
-	pub(crate) access_mask: ash::vk::AccessFlags,
-	pub(crate) image_layout: ash::vk::ImageLayout,
+	pub(crate) stage_mask: vk::PipelineStageFlags,
+	pub(crate) access_mask: vk::AccessFlags,
+	pub(crate) image_layout: vk::ImageLayout,
 }
 
 pub(crate) fn get_access_info(access_type: AccessType) -> AccessInfo {
 	match access_type {
 		AccessType::Nothing => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::empty(),
-			access_mask: ash::vk::AccessFlags::empty(),
-			image_layout: ash::vk::ImageLayout::UNDEFINED,
+			stage_mask: vk::PipelineStageFlags::empty(),
+			access_mask: vk::AccessFlags::empty(),
+			image_layout: vk::ImageLayout::UNDEFINED,
 		},
 		AccessType::CommandBufferReadNVX => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::COMMAND_PREPROCESS_NV,
-			access_mask: ash::vk::AccessFlags::COMMAND_PREPROCESS_READ_NV,
-			image_layout: ash::vk::ImageLayout::UNDEFINED,
+			stage_mask: vk::PipelineStageFlags::COMMAND_PREPROCESS_NV,
+			access_mask: vk::AccessFlags::COMMAND_PREPROCESS_READ_NV,
+			image_layout: vk::ImageLayout::UNDEFINED,
 		},
 		AccessType::IndirectBuffer => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::DRAW_INDIRECT,
-			access_mask: ash::vk::AccessFlags::INDIRECT_COMMAND_READ,
-			image_layout: ash::vk::ImageLayout::UNDEFINED,
+			stage_mask: vk::PipelineStageFlags::DRAW_INDIRECT,
+			access_mask: vk::AccessFlags::INDIRECT_COMMAND_READ,
+			image_layout: vk::ImageLayout::UNDEFINED,
 		},
 		AccessType::IndexBuffer => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::VERTEX_INPUT,
-			access_mask: ash::vk::AccessFlags::INDEX_READ,
-			image_layout: ash::vk::ImageLayout::UNDEFINED,
+			stage_mask: vk::PipelineStageFlags::VERTEX_INPUT,
+			access_mask: vk::AccessFlags::INDEX_READ,
+			image_layout: vk::ImageLayout::UNDEFINED,
 		},
 		AccessType::VertexBuffer => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::VERTEX_INPUT,
-			access_mask: ash::vk::AccessFlags::VERTEX_ATTRIBUTE_READ,
-			image_layout: ash::vk::ImageLayout::UNDEFINED,
+			stage_mask: vk::PipelineStageFlags::VERTEX_INPUT,
+			access_mask: vk::AccessFlags::VERTEX_ATTRIBUTE_READ,
+			image_layout: vk::ImageLayout::UNDEFINED,
 		},
 		AccessType::VertexShaderReadUniformBuffer => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::VERTEX_SHADER,
-			access_mask: ash::vk::AccessFlags::SHADER_READ,
-			image_layout: ash::vk::ImageLayout::UNDEFINED,
+			stage_mask: vk::PipelineStageFlags::VERTEX_SHADER,
+			access_mask: vk::AccessFlags::SHADER_READ,
+			image_layout: vk::ImageLayout::UNDEFINED,
 		},
 		AccessType::VertexShaderReadSampledImageOrUniformTexelBuffer => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::VERTEX_SHADER,
-			access_mask: ash::vk::AccessFlags::SHADER_READ,
-			image_layout: ash::vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
+			stage_mask: vk::PipelineStageFlags::VERTEX_SHADER,
+			access_mask: vk::AccessFlags::SHADER_READ,
+			image_layout: vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
 		},
 		AccessType::VertexShaderReadOther => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::VERTEX_SHADER,
-			access_mask: ash::vk::AccessFlags::SHADER_READ,
-			image_layout: ash::vk::ImageLayout::GENERAL,
+			stage_mask: vk::PipelineStageFlags::VERTEX_SHADER,
+			access_mask: vk::AccessFlags::SHADER_READ,
+			image_layout: vk::ImageLayout::GENERAL,
 		},
 		AccessType::TessellationControlShaderReadUniformBuffer => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::TESSELLATION_CONTROL_SHADER,
-			access_mask: ash::vk::AccessFlags::UNIFORM_READ,
-			image_layout: ash::vk::ImageLayout::UNDEFINED,
+			stage_mask: vk::PipelineStageFlags::TESSELLATION_CONTROL_SHADER,
+			access_mask: vk::AccessFlags::UNIFORM_READ,
+			image_layout: vk::ImageLayout::UNDEFINED,
 		},
 		AccessType::TessellationControlShaderReadSampledImageOrUniformTexelBuffer => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::TESSELLATION_CONTROL_SHADER,
-			access_mask: ash::vk::AccessFlags::SHADER_READ,
-			image_layout: ash::vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
+			stage_mask: vk::PipelineStageFlags::TESSELLATION_CONTROL_SHADER,
+			access_mask: vk::AccessFlags::SHADER_READ,
+			image_layout: vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
 		},
 		AccessType::TessellationControlShaderReadOther => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::TESSELLATION_CONTROL_SHADER,
-			access_mask: ash::vk::AccessFlags::SHADER_READ,
-			image_layout: ash::vk::ImageLayout::GENERAL,
+			stage_mask: vk::PipelineStageFlags::TESSELLATION_CONTROL_SHADER,
+			access_mask: vk::AccessFlags::SHADER_READ,
+			image_layout: vk::ImageLayout::GENERAL,
 		},
 		AccessType::TessellationEvaluationShaderReadUniformBuffer => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::TESSELLATION_EVALUATION_SHADER,
-			access_mask: ash::vk::AccessFlags::UNIFORM_READ,
-			image_layout: ash::vk::ImageLayout::UNDEFINED,
+			stage_mask: vk::PipelineStageFlags::TESSELLATION_EVALUATION_SHADER,
+			access_mask: vk::AccessFlags::UNIFORM_READ,
+			image_layout: vk::ImageLayout::UNDEFINED,
 		},
 		AccessType::TessellationEvaluationShaderReadSampledImageOrUniformTexelBuffer => {
 			AccessInfo {
-				stage_mask: ash::vk::PipelineStageFlags::TESSELLATION_EVALUATION_SHADER,
-				access_mask: ash::vk::AccessFlags::SHADER_READ,
-				image_layout: ash::vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
+				stage_mask: vk::PipelineStageFlags::TESSELLATION_EVALUATION_SHADER,
+				access_mask: vk::AccessFlags::SHADER_READ,
+				image_layout: vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
 			}
 		}
 		AccessType::TessellationEvaluationShaderReadOther => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::TESSELLATION_EVALUATION_SHADER,
-			access_mask: ash::vk::AccessFlags::SHADER_READ,
-			image_layout: ash::vk::ImageLayout::GENERAL,
+			stage_mask: vk::PipelineStageFlags::TESSELLATION_EVALUATION_SHADER,
+			access_mask: vk::AccessFlags::SHADER_READ,
+			image_layout: vk::ImageLayout::GENERAL,
 		},
 		AccessType::GeometryShaderReadUniformBuffer => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::GEOMETRY_SHADER,
-			access_mask: ash::vk::AccessFlags::UNIFORM_READ,
-			image_layout: ash::vk::ImageLayout::UNDEFINED,
+			stage_mask: vk::PipelineStageFlags::GEOMETRY_SHADER,
+			access_mask: vk::AccessFlags::UNIFORM_READ,
+			image_layout: vk::ImageLayout::UNDEFINED,
 		},
 		AccessType::GeometryShaderReadSampledImageOrUniformTexelBuffer => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::GEOMETRY_SHADER,
-			access_mask: ash::vk::AccessFlags::SHADER_READ,
-			image_layout: ash::vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
+			stage_mask: vk::PipelineStageFlags::GEOMETRY_SHADER,
+			access_mask: vk::AccessFlags::SHADER_READ,
+			image_layout: vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
 		},
 		AccessType::GeometryShaderReadOther => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::GEOMETRY_SHADER,
-			access_mask: ash::vk::AccessFlags::SHADER_READ,
-			image_layout: ash::vk::ImageLayout::GENERAL,
+			stage_mask: vk::PipelineStageFlags::GEOMETRY_SHADER,
+			access_mask: vk::AccessFlags::SHADER_READ,
+			image_layout: vk::ImageLayout::GENERAL,
 		},
 		AccessType::FragmentShaderReadUniformBuffer => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::FRAGMENT_SHADER,
-			access_mask: ash::vk::AccessFlags::UNIFORM_READ,
-			image_layout: ash::vk::ImageLayout::UNDEFINED,
+			stage_mask: vk::PipelineStageFlags::FRAGMENT_SHADER,
+			access_mask: vk::AccessFlags::UNIFORM_READ,
+			image_layout: vk::ImageLayout::UNDEFINED,
 		},
 		AccessType::FragmentShaderReadSampledImageOrUniformTexelBuffer => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::FRAGMENT_SHADER,
-			access_mask: ash::vk::AccessFlags::SHADER_READ,
-			image_layout: ash::vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
+			stage_mask: vk::PipelineStageFlags::FRAGMENT_SHADER,
+			access_mask: vk::AccessFlags::SHADER_READ,
+			image_layout: vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
 		},
 		AccessType::FragmentShaderReadColorInputAttachment => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::FRAGMENT_SHADER,
-			access_mask: ash::vk::AccessFlags::INPUT_ATTACHMENT_READ,
-			image_layout: ash::vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
+			stage_mask: vk::PipelineStageFlags::FRAGMENT_SHADER,
+			access_mask: vk::AccessFlags::INPUT_ATTACHMENT_READ,
+			image_layout: vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
 		},
 		AccessType::FragmentShaderReadDepthStencilInputAttachment => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::FRAGMENT_SHADER,
-			access_mask: ash::vk::AccessFlags::INPUT_ATTACHMENT_READ,
-			image_layout: ash::vk::ImageLayout::DEPTH_STENCIL_READ_ONLY_OPTIMAL,
+			stage_mask: vk::PipelineStageFlags::FRAGMENT_SHADER,
+			access_mask: vk::AccessFlags::INPUT_ATTACHMENT_READ,
+			image_layout: vk::ImageLayout::DEPTH_STENCIL_READ_ONLY_OPTIMAL,
 		},
 		AccessType::FragmentShaderReadOther => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::FRAGMENT_SHADER,
-			access_mask: ash::vk::AccessFlags::SHADER_READ,
-			image_layout: ash::vk::ImageLayout::GENERAL,
+			stage_mask: vk::PipelineStageFlags::FRAGMENT_SHADER,
+			access_mask: vk::AccessFlags::SHADER_READ,
+			image_layout: vk::ImageLayout::GENERAL,
 		},
 		AccessType::ColorAttachmentRead => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT,
-			access_mask: ash::vk::AccessFlags::COLOR_ATTACHMENT_READ,
-			image_layout: ash::vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
+			stage_mask: vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT,
+			access_mask: vk::AccessFlags::COLOR_ATTACHMENT_READ,
+			image_layout: vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
 		},
 		AccessType::DepthStencilAttachmentRead => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::EARLY_FRAGMENT_TESTS
-				| ash::vk::PipelineStageFlags::LATE_FRAGMENT_TESTS,
-			access_mask: ash::vk::AccessFlags::DEPTH_STENCIL_ATTACHMENT_READ,
-			image_layout: ash::vk::ImageLayout::DEPTH_STENCIL_READ_ONLY_OPTIMAL,
+			stage_mask: vk::PipelineStageFlags::EARLY_FRAGMENT_TESTS
+				| vk::PipelineStageFlags::LATE_FRAGMENT_TESTS,
+			access_mask: vk::AccessFlags::DEPTH_STENCIL_ATTACHMENT_READ,
+			image_layout: vk::ImageLayout::DEPTH_STENCIL_READ_ONLY_OPTIMAL,
 		},
 		AccessType::ComputeShaderReadUniformBuffer => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::COMPUTE_SHADER,
-			access_mask: ash::vk::AccessFlags::UNIFORM_READ,
-			image_layout: ash::vk::ImageLayout::UNDEFINED,
+			stage_mask: vk::PipelineStageFlags::COMPUTE_SHADER,
+			access_mask: vk::AccessFlags::UNIFORM_READ,
+			image_layout: vk::ImageLayout::UNDEFINED,
 		},
 		AccessType::ComputeShaderReadSampledImageOrUniformTexelBuffer => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::COMPUTE_SHADER,
-			access_mask: ash::vk::AccessFlags::SHADER_READ,
-			image_layout: ash::vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
+			stage_mask: vk::PipelineStageFlags::COMPUTE_SHADER,
+			access_mask: vk::AccessFlags::SHADER_READ,
+			image_layout: vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
 		},
 		AccessType::ComputeShaderReadOther => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::COMPUTE_SHADER,
-			access_mask: ash::vk::AccessFlags::SHADER_READ,
-			image_layout: ash::vk::ImageLayout::GENERAL,
+			stage_mask: vk::PipelineStageFlags::COMPUTE_SHADER,
+			access_mask: vk::AccessFlags::SHADER_READ,
+			image_layout: vk::ImageLayout::GENERAL,
 		},
 		AccessType::AnyShaderReadUniformBuffer => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::ALL_COMMANDS,
-			access_mask: ash::vk::AccessFlags::UNIFORM_READ,
-			image_layout: ash::vk::ImageLayout::UNDEFINED,
+			stage_mask: vk::PipelineStageFlags::ALL_COMMANDS,
+			access_mask: vk::AccessFlags::UNIFORM_READ,
+			image_layout: vk::ImageLayout::UNDEFINED,
 		},
 		AccessType::AnyShaderReadUniformBufferOrVertexBuffer => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::ALL_COMMANDS,
-			access_mask: ash::vk::AccessFlags::UNIFORM_READ
-				| ash::vk::AccessFlags::VERTEX_ATTRIBUTE_READ,
-			image_layout: ash::vk::ImageLayout::UNDEFINED,
+			stage_mask: vk::PipelineStageFlags::ALL_COMMANDS,
+			access_mask: vk::AccessFlags::UNIFORM_READ | vk::AccessFlags::VERTEX_ATTRIBUTE_READ,
+			image_layout: vk::ImageLayout::UNDEFINED,
 		},
 		AccessType::AnyShaderReadSampledImageOrUniformTexelBuffer => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::ALL_COMMANDS,
-			access_mask: ash::vk::AccessFlags::SHADER_READ,
-			image_layout: ash::vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
+			stage_mask: vk::PipelineStageFlags::ALL_COMMANDS,
+			access_mask: vk::AccessFlags::SHADER_READ,
+			image_layout: vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
 		},
 		AccessType::AnyShaderReadOther => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::ALL_COMMANDS,
-			access_mask: ash::vk::AccessFlags::SHADER_READ,
-			image_layout: ash::vk::ImageLayout::GENERAL,
+			stage_mask: vk::PipelineStageFlags::ALL_COMMANDS,
+			access_mask: vk::AccessFlags::SHADER_READ,
+			image_layout: vk::ImageLayout::GENERAL,
 		},
 		AccessType::TransferRead => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::TRANSFER,
-			access_mask: ash::vk::AccessFlags::TRANSFER_READ,
-			image_layout: ash::vk::ImageLayout::TRANSFER_SRC_OPTIMAL,
+			stage_mask: vk::PipelineStageFlags::TRANSFER,
+			access_mask: vk::AccessFlags::TRANSFER_READ,
+			image_layout: vk::ImageLayout::TRANSFER_SRC_OPTIMAL,
 		},
 		AccessType::HostRead => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::HOST,
-			access_mask: ash::vk::AccessFlags::HOST_READ,
-			image_layout: ash::vk::ImageLayout::GENERAL,
+			stage_mask: vk::PipelineStageFlags::HOST,
+			access_mask: vk::AccessFlags::HOST_READ,
+			image_layout: vk::ImageLayout::GENERAL,
 		},
 		AccessType::Present => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::empty(),
-			access_mask: ash::vk::AccessFlags::empty(),
-			image_layout: ash::vk::ImageLayout::PRESENT_SRC_KHR,
+			stage_mask: vk::PipelineStageFlags::empty(),
+			access_mask: vk::AccessFlags::empty(),
+			image_layout: vk::ImageLayout::PRESENT_SRC_KHR,
 		},
 		AccessType::CommandBufferWriteNVX => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::COMMAND_PREPROCESS_NV,
-			access_mask: ash::vk::AccessFlags::COMMAND_PREPROCESS_WRITE_NV,
-			image_layout: ash::vk::ImageLayout::UNDEFINED,
+			stage_mask: vk::PipelineStageFlags::COMMAND_PREPROCESS_NV,
+			access_mask: vk::AccessFlags::COMMAND_PREPROCESS_WRITE_NV,
+			image_layout: vk::ImageLayout::UNDEFINED,
 		},
 		AccessType::VertexShaderWrite => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::VERTEX_SHADER,
-			access_mask: ash::vk::AccessFlags::SHADER_WRITE,
-			image_layout: ash::vk::ImageLayout::GENERAL,
+			stage_mask: vk::PipelineStageFlags::VERTEX_SHADER,
+			access_mask: vk::AccessFlags::SHADER_WRITE,
+			image_layout: vk::ImageLayout::GENERAL,
 		},
 		AccessType::TessellationControlShaderWrite => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::TESSELLATION_CONTROL_SHADER,
-			access_mask: ash::vk::AccessFlags::SHADER_WRITE,
-			image_layout: ash::vk::ImageLayout::GENERAL,
+			stage_mask: vk::PipelineStageFlags::TESSELLATION_CONTROL_SHADER,
+			access_mask: vk::AccessFlags::SHADER_WRITE,
+			image_layout: vk::ImageLayout::GENERAL,
 		},
 		AccessType::TessellationEvaluationShaderWrite => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::TESSELLATION_EVALUATION_SHADER,
-			access_mask: ash::vk::AccessFlags::SHADER_WRITE,
-			image_layout: ash::vk::ImageLayout::GENERAL,
+			stage_mask: vk::PipelineStageFlags::TESSELLATION_EVALUATION_SHADER,
+			access_mask: vk::AccessFlags::SHADER_WRITE,
+			image_layout: vk::ImageLayout::GENERAL,
 		},
 		AccessType::GeometryShaderWrite => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::GEOMETRY_SHADER,
-			access_mask: ash::vk::AccessFlags::SHADER_WRITE,
-			image_layout: ash::vk::ImageLayout::GENERAL,
+			stage_mask: vk::PipelineStageFlags::GEOMETRY_SHADER,
+			access_mask: vk::AccessFlags::SHADER_WRITE,
+			image_layout: vk::ImageLayout::GENERAL,
 		},
 		AccessType::FragmentShaderWrite => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::FRAGMENT_SHADER,
-			access_mask: ash::vk::AccessFlags::SHADER_WRITE,
-			image_layout: ash::vk::ImageLayout::GENERAL,
+			stage_mask: vk::PipelineStageFlags::FRAGMENT_SHADER,
+			access_mask: vk::AccessFlags::SHADER_WRITE,
+			image_layout: vk::ImageLayout::GENERAL,
 		},
 		AccessType::ColorAttachmentWrite => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT,
-			access_mask: ash::vk::AccessFlags::COLOR_ATTACHMENT_WRITE,
-			image_layout: ash::vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
+			stage_mask: vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT,
+			access_mask: vk::AccessFlags::COLOR_ATTACHMENT_WRITE,
+			image_layout: vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
 		},
 		AccessType::DepthStencilAttachmentWrite => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::EARLY_FRAGMENT_TESTS
-				| ash::vk::PipelineStageFlags::LATE_FRAGMENT_TESTS,
-			access_mask: ash::vk::AccessFlags::DEPTH_STENCIL_ATTACHMENT_WRITE,
-			image_layout: ash::vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
+			stage_mask: vk::PipelineStageFlags::EARLY_FRAGMENT_TESTS
+				| vk::PipelineStageFlags::LATE_FRAGMENT_TESTS,
+			access_mask: vk::AccessFlags::DEPTH_STENCIL_ATTACHMENT_WRITE,
+			image_layout: vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
 		},
 		AccessType::DepthAttachmentWriteStencilReadOnly => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::EARLY_FRAGMENT_TESTS
-				| ash::vk::PipelineStageFlags::LATE_FRAGMENT_TESTS,
-			access_mask: ash::vk::AccessFlags::DEPTH_STENCIL_ATTACHMENT_WRITE
-				| ash::vk::AccessFlags::DEPTH_STENCIL_ATTACHMENT_READ,
-			image_layout: ash::vk::ImageLayout::DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL,
+			stage_mask: vk::PipelineStageFlags::EARLY_FRAGMENT_TESTS
+				| vk::PipelineStageFlags::LATE_FRAGMENT_TESTS,
+			access_mask: vk::AccessFlags::DEPTH_STENCIL_ATTACHMENT_WRITE
+				| vk::AccessFlags::DEPTH_STENCIL_ATTACHMENT_READ,
+			image_layout: vk::ImageLayout::DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL,
 		},
 		AccessType::StencilAttachmentWriteDepthReadOnly => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::EARLY_FRAGMENT_TESTS
-				| ash::vk::PipelineStageFlags::LATE_FRAGMENT_TESTS,
-			access_mask: ash::vk::AccessFlags::DEPTH_STENCIL_ATTACHMENT_WRITE
-				| ash::vk::AccessFlags::DEPTH_STENCIL_ATTACHMENT_READ,
-			image_layout: ash::vk::ImageLayout::DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL,
+			stage_mask: vk::PipelineStageFlags::EARLY_FRAGMENT_TESTS
+				| vk::PipelineStageFlags::LATE_FRAGMENT_TESTS,
+			access_mask: vk::AccessFlags::DEPTH_STENCIL_ATTACHMENT_WRITE
+				| vk::AccessFlags::DEPTH_STENCIL_ATTACHMENT_READ,
+			image_layout: vk::ImageLayout::DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL,
 		},
 		AccessType::ComputeShaderWrite => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::COMPUTE_SHADER,
-			access_mask: ash::vk::AccessFlags::SHADER_WRITE,
-			image_layout: ash::vk::ImageLayout::GENERAL,
+			stage_mask: vk::PipelineStageFlags::COMPUTE_SHADER,
+			access_mask: vk::AccessFlags::SHADER_WRITE,
+			image_layout: vk::ImageLayout::GENERAL,
 		},
 		AccessType::AnyShaderWrite => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::ALL_COMMANDS,
-			access_mask: ash::vk::AccessFlags::SHADER_WRITE,
-			image_layout: ash::vk::ImageLayout::GENERAL,
+			stage_mask: vk::PipelineStageFlags::ALL_COMMANDS,
+			access_mask: vk::AccessFlags::SHADER_WRITE,
+			image_layout: vk::ImageLayout::GENERAL,
 		},
 		AccessType::TransferWrite => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::TRANSFER,
-			access_mask: ash::vk::AccessFlags::TRANSFER_WRITE,
-			image_layout: ash::vk::ImageLayout::TRANSFER_DST_OPTIMAL,
+			stage_mask: vk::PipelineStageFlags::TRANSFER,
+			access_mask: vk::AccessFlags::TRANSFER_WRITE,
+			image_layout: vk::ImageLayout::TRANSFER_DST_OPTIMAL,
 		},
 		AccessType::HostWrite => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::HOST,
-			access_mask: ash::vk::AccessFlags::HOST_WRITE,
-			image_layout: ash::vk::ImageLayout::GENERAL,
+			stage_mask: vk::PipelineStageFlags::HOST,
+			access_mask: vk::AccessFlags::HOST_WRITE,
+			image_layout: vk::ImageLayout::GENERAL,
 		},
 		AccessType::ColorAttachmentReadWrite => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT,
-			access_mask: ash::vk::AccessFlags::COLOR_ATTACHMENT_READ
-				| ash::vk::AccessFlags::COLOR_ATTACHMENT_WRITE,
-			image_layout: ash::vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
+			stage_mask: vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT,
+			access_mask: vk::AccessFlags::COLOR_ATTACHMENT_READ
+				| vk::AccessFlags::COLOR_ATTACHMENT_WRITE,
+			image_layout: vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL,
 		},
 		AccessType::General => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::ALL_COMMANDS,
-			access_mask: ash::vk::AccessFlags::MEMORY_READ | ash::vk::AccessFlags::MEMORY_WRITE,
-			image_layout: ash::vk::ImageLayout::GENERAL,
+			stage_mask: vk::PipelineStageFlags::ALL_COMMANDS,
+			access_mask: vk::AccessFlags::MEMORY_READ | vk::AccessFlags::MEMORY_WRITE,
+			image_layout: vk::ImageLayout::GENERAL,
 		},
 	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -501,8 +501,8 @@ pub(crate) fn get_access_info(access_type: AccessType) -> AccessInfo {
 			image_layout: ash::vk::ImageLayout::UNDEFINED,
 		},
 		AccessType::CommandBufferReadNVX => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::COMMAND_PROCESS_NVX,
-			access_mask: ash::vk::AccessFlags::COMMAND_PROCESS_READ_NVX,
+			stage_mask: ash::vk::PipelineStageFlags::COMMAND_PREPROCESS_NV,
+			access_mask: ash::vk::AccessFlags::COMMAND_PREPROCESS_READ_NV,
 			image_layout: ash::vk::ImageLayout::UNDEFINED,
 		},
 		AccessType::IndirectBuffer => AccessInfo {
@@ -670,8 +670,8 @@ pub(crate) fn get_access_info(access_type: AccessType) -> AccessInfo {
 			image_layout: ash::vk::ImageLayout::PRESENT_SRC_KHR,
 		},
 		AccessType::CommandBufferWriteNVX => AccessInfo {
-			stage_mask: ash::vk::PipelineStageFlags::COMMAND_PROCESS_NVX,
-			access_mask: ash::vk::AccessFlags::COMMAND_PROCESS_WRITE_NVX,
+			stage_mask: ash::vk::PipelineStageFlags::COMMAND_PREPROCESS_NV,
+			access_mask: ash::vk::AccessFlags::COMMAND_PREPROCESS_WRITE_NV,
 			image_layout: ash::vk::ImageLayout::UNDEFINED,
 		},
 		AccessType::VertexShaderWrite => AccessInfo {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,8 @@
 //!
 //! Rather than the complex maze of enums and bit flags in Vulkan - many
 //! combinations of which are invalid or nonsensical - this library collapses
-//! this to a much shorter list of ~40 distinct usage types, and a couple of
-//! options for handling image layouts.
+//! this to a shorter list of distinct usage types, and a couple of options
+//! for handling image layouts.
 //!
 //! Additionally, these usage types provide an easier mapping to other graphics
 //! APIs like DirectX 12.
@@ -171,6 +171,30 @@ pub enum AccessType {
 
 	/// Covers any access - useful for debug, generally avoid for performance reasons
 	General,
+
+	/// Read as a sampled image/uniform texel buffer in a ray tracing shader
+	RayTracingShaderReadSampledImageOrUniformTexelBuffer,
+
+	/// Read as an input attachment with a color format in a ray tracing shader
+	RayTracingShaderReadColorInputAttachment,
+
+	/// Read as an input attachment with a depth/stencil format in a ray tracing shader
+	RayTracingShaderReadDepthStencilInputAttachment,
+
+	/// Read as an acceleration structure in a ray tracing shader
+	RayTracingShaderReadAccelerationStructure,
+
+	/// Read as any other resource in a ray tracing shader
+	RayTracingShaderReadOther,
+
+	/// Written as an acceleration structure during acceleration structure building
+	AccelerationStructureBuildWrite,
+
+	/// Read as an acceleration structure during acceleration structure building (e.g. a BLAS when building a TLAS)
+	AccelerationStructureBuildRead,
+
+	// Written as a buffer during acceleration structure building (e.g. a staging buffer)
+	AccelerationStructureBufferWrite,
 }
 
 impl Default for AccessType {
@@ -749,6 +773,46 @@ pub(crate) fn get_access_info(access_type: AccessType) -> AccessInfo {
 			stage_mask: vk::PipelineStageFlags::ALL_COMMANDS,
 			access_mask: vk::AccessFlags::MEMORY_READ | vk::AccessFlags::MEMORY_WRITE,
 			image_layout: vk::ImageLayout::GENERAL,
+		},
+		AccessType::RayTracingShaderReadSampledImageOrUniformTexelBuffer => AccessInfo {
+			stage_mask: vk::PipelineStageFlags::RAY_TRACING_SHADER_KHR,
+			access_mask: vk::AccessFlags::SHADER_READ,
+			image_layout: vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
+		},
+		AccessType::RayTracingShaderReadColorInputAttachment => AccessInfo {
+			stage_mask: vk::PipelineStageFlags::RAY_TRACING_SHADER_KHR,
+			access_mask: vk::AccessFlags::INPUT_ATTACHMENT_READ,
+			image_layout: vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL,
+		},
+		AccessType::RayTracingShaderReadDepthStencilInputAttachment => AccessInfo {
+			stage_mask: vk::PipelineStageFlags::RAY_TRACING_SHADER_KHR,
+			access_mask: vk::AccessFlags::INPUT_ATTACHMENT_READ,
+			image_layout: vk::ImageLayout::DEPTH_STENCIL_READ_ONLY_OPTIMAL,
+		},
+		AccessType::RayTracingShaderReadAccelerationStructure => AccessInfo {
+			stage_mask: vk::PipelineStageFlags::RAY_TRACING_SHADER_KHR,
+			access_mask: vk::AccessFlags::ACCELERATION_STRUCTURE_READ_KHR,
+			image_layout: vk::ImageLayout::UNDEFINED,
+		},
+		AccessType::RayTracingShaderReadOther => AccessInfo {
+			stage_mask: vk::PipelineStageFlags::RAY_TRACING_SHADER_KHR,
+			access_mask: vk::AccessFlags::SHADER_READ,
+			image_layout: vk::ImageLayout::GENERAL,
+		},
+		AccessType::AccelerationStructureBuildWrite => AccessInfo {
+			stage_mask: vk::PipelineStageFlags::ACCELERATION_STRUCTURE_BUILD_KHR,
+			access_mask: vk::AccessFlags::ACCELERATION_STRUCTURE_WRITE_KHR,
+			image_layout: vk::ImageLayout::UNDEFINED,
+		},
+		AccessType::AccelerationStructureBuildRead => AccessInfo {
+			stage_mask: vk::PipelineStageFlags::ACCELERATION_STRUCTURE_BUILD_KHR,
+			access_mask: vk::AccessFlags::ACCELERATION_STRUCTURE_READ_KHR,
+			image_layout: vk::ImageLayout::UNDEFINED,
+		},
+		AccessType::AccelerationStructureBufferWrite => AccessInfo {
+			stage_mask: vk::PipelineStageFlags::ACCELERATION_STRUCTURE_BUILD_KHR,
+			access_mask: vk::AccessFlags::TRANSFER_WRITE,
+			image_layout: vk::ImageLayout::UNDEFINED,
 		},
 	}
 }

--- a/tests/global.rs
+++ b/tests/global.rs
@@ -1,7 +1,6 @@
 //! Tests are based on the common synchronization examples on the Vulkan-Docs wiki: https://github.com/KhronosGroup/Vulkan-Docs/wiki/Synchronization-Examples.
 
-extern crate ash;
-extern crate vk_sync;
+use ash::vk;
 
 #[test]
 fn compute_write_storage_compute_read_storage() {
@@ -13,10 +12,10 @@ fn compute_write_storage_compute_read_storage() {
 
 	let (src_mask, dst_mask, barrier) = vk_sync::get_memory_barrier(&global_barrier);
 
-	assert_eq!(src_mask, ash::vk::PipelineStageFlags::COMPUTE_SHADER);
-	assert_eq!(dst_mask, ash::vk::PipelineStageFlags::COMPUTE_SHADER);
-	assert_eq!(barrier.src_access_mask, ash::vk::AccessFlags::SHADER_WRITE);
-	assert_eq!(barrier.dst_access_mask, ash::vk::AccessFlags::SHADER_READ);
+	assert_eq!(src_mask, vk::PipelineStageFlags::COMPUTE_SHADER);
+	assert_eq!(dst_mask, vk::PipelineStageFlags::COMPUTE_SHADER);
+	assert_eq!(barrier.src_access_mask, vk::AccessFlags::SHADER_WRITE);
+	assert_eq!(barrier.dst_access_mask, vk::AccessFlags::SHADER_READ);
 }
 
 #[test]
@@ -29,10 +28,10 @@ fn compute_read_storage_compute_write_storage() {
 
 	let (src_mask, dst_mask, barrier) = vk_sync::get_memory_barrier(&global_barrier);
 
-	assert_eq!(src_mask, ash::vk::PipelineStageFlags::COMPUTE_SHADER);
-	assert_eq!(dst_mask, ash::vk::PipelineStageFlags::COMPUTE_SHADER);
-	assert_eq!(barrier.src_access_mask, ash::vk::AccessFlags::SHADER_WRITE);
-	assert_eq!(barrier.dst_access_mask, ash::vk::AccessFlags::SHADER_READ);
+	assert_eq!(src_mask, vk::PipelineStageFlags::COMPUTE_SHADER);
+	assert_eq!(dst_mask, vk::PipelineStageFlags::COMPUTE_SHADER);
+	assert_eq!(barrier.src_access_mask, vk::AccessFlags::SHADER_WRITE);
+	assert_eq!(barrier.dst_access_mask, vk::AccessFlags::SHADER_READ);
 }
 
 #[test]
@@ -45,10 +44,10 @@ fn compute_write_storage_graphics_read_index() {
 
 	let (src_mask, dst_mask, barrier) = vk_sync::get_memory_barrier(&global_barrier);
 
-	assert_eq!(src_mask, ash::vk::PipelineStageFlags::COMPUTE_SHADER);
-	assert_eq!(dst_mask, ash::vk::PipelineStageFlags::VERTEX_INPUT);
-	assert_eq!(barrier.src_access_mask, ash::vk::AccessFlags::SHADER_WRITE);
-	assert_eq!(barrier.dst_access_mask, ash::vk::AccessFlags::INDEX_READ);
+	assert_eq!(src_mask, vk::PipelineStageFlags::COMPUTE_SHADER);
+	assert_eq!(dst_mask, vk::PipelineStageFlags::VERTEX_INPUT);
+	assert_eq!(barrier.src_access_mask, vk::AccessFlags::SHADER_WRITE);
+	assert_eq!(barrier.dst_access_mask, vk::AccessFlags::INDEX_READ);
 }
 
 #[test]
@@ -61,12 +60,12 @@ fn compute_write_storage_graphics_read_indirect() {
 
 	let (src_mask, dst_mask, barrier) = vk_sync::get_memory_barrier(&global_barrier);
 
-	assert_eq!(src_mask, ash::vk::PipelineStageFlags::COMPUTE_SHADER);
-	assert_eq!(dst_mask, ash::vk::PipelineStageFlags::DRAW_INDIRECT);
-	assert_eq!(barrier.src_access_mask, ash::vk::AccessFlags::SHADER_WRITE);
+	assert_eq!(src_mask, vk::PipelineStageFlags::COMPUTE_SHADER);
+	assert_eq!(dst_mask, vk::PipelineStageFlags::DRAW_INDIRECT);
+	assert_eq!(barrier.src_access_mask, vk::AccessFlags::SHADER_WRITE);
 	assert_eq!(
 		barrier.dst_access_mask,
-		ash::vk::AccessFlags::INDIRECT_COMMAND_READ
+		vk::AccessFlags::INDIRECT_COMMAND_READ
 	);
 }
 
@@ -80,10 +79,10 @@ fn nothing_transfer_read() {
 
 	let (src_mask, dst_mask, barrier) = vk_sync::get_memory_barrier(&global_barrier);
 
-	assert_eq!(src_mask, ash::vk::PipelineStageFlags::TOP_OF_PIPE);
-	assert_eq!(dst_mask, ash::vk::PipelineStageFlags::TRANSFER);
-	assert_eq!(barrier.src_access_mask, ash::vk::AccessFlags::empty());
-	assert_eq!(barrier.dst_access_mask, ash::vk::AccessFlags::empty());
+	assert_eq!(src_mask, vk::PipelineStageFlags::TOP_OF_PIPE);
+	assert_eq!(dst_mask, vk::PipelineStageFlags::TRANSFER);
+	assert_eq!(barrier.src_access_mask, vk::AccessFlags::empty());
+	assert_eq!(barrier.dst_access_mask, vk::AccessFlags::empty());
 }
 
 #[test]
@@ -96,15 +95,12 @@ fn transfer_write_graphics_read_vertex() {
 
 	let (src_mask, dst_mask, barrier) = vk_sync::get_memory_barrier(&global_barrier);
 
-	assert_eq!(src_mask, ash::vk::PipelineStageFlags::TRANSFER);
-	assert_eq!(dst_mask, ash::vk::PipelineStageFlags::VERTEX_INPUT);
-	assert_eq!(
-		barrier.src_access_mask,
-		ash::vk::AccessFlags::TRANSFER_WRITE
-	);
+	assert_eq!(src_mask, vk::PipelineStageFlags::TRANSFER);
+	assert_eq!(dst_mask, vk::PipelineStageFlags::VERTEX_INPUT);
+	assert_eq!(barrier.src_access_mask, vk::AccessFlags::TRANSFER_WRITE);
 	assert_eq!(
 		barrier.dst_access_mask,
-		ash::vk::AccessFlags::VERTEX_ATTRIBUTE_READ
+		vk::AccessFlags::VERTEX_ATTRIBUTE_READ
 	);
 }
 
@@ -118,15 +114,15 @@ fn full_pipeline_barrier() {
 
 	let (src_mask, dst_mask, barrier) = vk_sync::get_memory_barrier(&global_barrier);
 
-	assert_eq!(src_mask, ash::vk::PipelineStageFlags::ALL_COMMANDS);
-	assert_eq!(dst_mask, ash::vk::PipelineStageFlags::ALL_COMMANDS);
+	assert_eq!(src_mask, vk::PipelineStageFlags::ALL_COMMANDS);
+	assert_eq!(dst_mask, vk::PipelineStageFlags::ALL_COMMANDS);
 	assert_eq!(
 		barrier.src_access_mask,
-		ash::vk::AccessFlags::MEMORY_READ | ash::vk::AccessFlags::MEMORY_WRITE
+		vk::AccessFlags::MEMORY_READ | vk::AccessFlags::MEMORY_WRITE
 	);
 	assert_eq!(
 		barrier.dst_access_mask,
-		ash::vk::AccessFlags::MEMORY_READ | ash::vk::AccessFlags::MEMORY_WRITE
+		vk::AccessFlags::MEMORY_READ | vk::AccessFlags::MEMORY_WRITE
 	);
 }
 
@@ -143,15 +139,15 @@ fn compute_write_storage_graphics_read_index_compute_read_uniform() {
 
 	let (src_mask, dst_mask, barrier) = vk_sync::get_memory_barrier(&global_barrier);
 
-	assert_eq!(src_mask, ash::vk::PipelineStageFlags::COMPUTE_SHADER);
+	assert_eq!(src_mask, vk::PipelineStageFlags::COMPUTE_SHADER);
 	assert_eq!(
 		dst_mask,
-		ash::vk::PipelineStageFlags::VERTEX_INPUT | ash::vk::PipelineStageFlags::COMPUTE_SHADER
+		vk::PipelineStageFlags::VERTEX_INPUT | vk::PipelineStageFlags::COMPUTE_SHADER
 	);
-	assert_eq!(barrier.src_access_mask, ash::vk::AccessFlags::SHADER_WRITE);
+	assert_eq!(barrier.src_access_mask, vk::AccessFlags::SHADER_WRITE);
 	assert_eq!(
 		barrier.dst_access_mask,
-		ash::vk::AccessFlags::INDEX_READ | ash::vk::AccessFlags::UNIFORM_READ
+		vk::AccessFlags::INDEX_READ | vk::AccessFlags::UNIFORM_READ
 	);
 }
 
@@ -168,14 +164,14 @@ fn compute_write_texel_graphics_read_indirect_fragment_read_uniform() {
 
 	let (src_mask, dst_mask, barrier) = vk_sync::get_memory_barrier(&global_barrier);
 
-	assert_eq!(src_mask, ash::vk::PipelineStageFlags::COMPUTE_SHADER);
+	assert_eq!(src_mask, vk::PipelineStageFlags::COMPUTE_SHADER);
 	assert_eq!(
 		dst_mask,
-		ash::vk::PipelineStageFlags::DRAW_INDIRECT | ash::vk::PipelineStageFlags::FRAGMENT_SHADER
+		vk::PipelineStageFlags::DRAW_INDIRECT | vk::PipelineStageFlags::FRAGMENT_SHADER
 	);
-	assert_eq!(barrier.src_access_mask, ash::vk::AccessFlags::SHADER_WRITE);
+	assert_eq!(barrier.src_access_mask, vk::AccessFlags::SHADER_WRITE);
 	assert_eq!(
 		barrier.dst_access_mask,
-		ash::vk::AccessFlags::INDIRECT_COMMAND_READ | ash::vk::AccessFlags::UNIFORM_READ
+		vk::AccessFlags::INDIRECT_COMMAND_READ | vk::AccessFlags::UNIFORM_READ
 	);
 }

--- a/tests/image.rs
+++ b/tests/image.rs
@@ -1,7 +1,6 @@
 //! Tests are based on the common synchronization examples on the Vulkan-Docs wiki: https://github.com/KhronosGroup/Vulkan-Docs/wiki/Synchronization-Examples.
 
-extern crate ash;
-extern crate vk_sync;
+use ash::vk;
 
 #[test]
 fn compute_write_storage_fragment_read_sampled() {
@@ -14,9 +13,9 @@ fn compute_write_storage_fragment_read_sampled() {
 		discard_contents: false,
 		src_queue_family_index: 0,
 		dst_queue_family_index: 0,
-		image: ash::vk::Image::null(),
-		range: ash::vk::ImageSubresourceRange {
-			aspect_mask: ash::vk::ImageAspectFlags::empty(),
+		image: vk::Image::null(),
+		range: vk::ImageSubresourceRange {
+			aspect_mask: vk::ImageAspectFlags::empty(),
 			base_mip_level: 0,
 			level_count: 1,
 			base_array_layer: 0,
@@ -26,14 +25,14 @@ fn compute_write_storage_fragment_read_sampled() {
 
 	let (src_mask, dst_mask, barrier) = vk_sync::get_image_memory_barrier(&image_barrier);
 
-	assert_eq!(src_mask, ash::vk::PipelineStageFlags::COMPUTE_SHADER);
-	assert_eq!(dst_mask, ash::vk::PipelineStageFlags::FRAGMENT_SHADER);
-	assert_eq!(barrier.src_access_mask, ash::vk::AccessFlags::SHADER_WRITE);
-	assert_eq!(barrier.dst_access_mask, ash::vk::AccessFlags::SHADER_READ);
-	assert_eq!(barrier.old_layout, ash::vk::ImageLayout::GENERAL);
+	assert_eq!(src_mask, vk::PipelineStageFlags::COMPUTE_SHADER);
+	assert_eq!(dst_mask, vk::PipelineStageFlags::FRAGMENT_SHADER);
+	assert_eq!(barrier.src_access_mask, vk::AccessFlags::SHADER_WRITE);
+	assert_eq!(barrier.dst_access_mask, vk::AccessFlags::SHADER_READ);
+	assert_eq!(barrier.old_layout, vk::ImageLayout::GENERAL);
 	assert_eq!(
 		barrier.new_layout,
-		ash::vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL
+		vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL
 	);
 }
 
@@ -48,9 +47,9 @@ fn graphics_write_color_compute_read_sampled() {
 		discard_contents: false,
 		src_queue_family_index: 0,
 		dst_queue_family_index: 0,
-		image: ash::vk::Image::null(),
-		range: ash::vk::ImageSubresourceRange {
-			aspect_mask: ash::vk::ImageAspectFlags::empty(),
+		image: vk::Image::null(),
+		range: vk::ImageSubresourceRange {
+			aspect_mask: vk::ImageAspectFlags::empty(),
 			base_mip_level: 0,
 			level_count: 1,
 			base_array_layer: 0,
@@ -60,23 +59,20 @@ fn graphics_write_color_compute_read_sampled() {
 
 	let (src_mask, dst_mask, barrier) = vk_sync::get_image_memory_barrier(&image_barrier);
 
-	assert_eq!(
-		src_mask,
-		ash::vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT
-	);
-	assert_eq!(dst_mask, ash::vk::PipelineStageFlags::COMPUTE_SHADER);
+	assert_eq!(src_mask, vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT);
+	assert_eq!(dst_mask, vk::PipelineStageFlags::COMPUTE_SHADER);
 	assert_eq!(
 		barrier.src_access_mask,
-		ash::vk::AccessFlags::COLOR_ATTACHMENT_WRITE
+		vk::AccessFlags::COLOR_ATTACHMENT_WRITE
 	);
-	assert_eq!(barrier.dst_access_mask, ash::vk::AccessFlags::SHADER_READ);
+	assert_eq!(barrier.dst_access_mask, vk::AccessFlags::SHADER_READ);
 	assert_eq!(
 		barrier.old_layout,
-		ash::vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL
+		vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL
 	);
 	assert_eq!(
 		barrier.new_layout,
-		ash::vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL
+		vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL
 	);
 }
 
@@ -91,9 +87,9 @@ fn graphics_write_depth_compute_read_sampled() {
 		discard_contents: false,
 		src_queue_family_index: 0,
 		dst_queue_family_index: 0,
-		image: ash::vk::Image::null(),
-		range: ash::vk::ImageSubresourceRange {
-			aspect_mask: ash::vk::ImageAspectFlags::empty(),
+		image: vk::Image::null(),
+		range: vk::ImageSubresourceRange {
+			aspect_mask: vk::ImageAspectFlags::empty(),
 			base_mip_level: 0,
 			level_count: 1,
 			base_array_layer: 0,
@@ -105,22 +101,21 @@ fn graphics_write_depth_compute_read_sampled() {
 
 	assert_eq!(
 		src_mask,
-		ash::vk::PipelineStageFlags::EARLY_FRAGMENT_TESTS
-			| ash::vk::PipelineStageFlags::LATE_FRAGMENT_TESTS
+		vk::PipelineStageFlags::EARLY_FRAGMENT_TESTS | vk::PipelineStageFlags::LATE_FRAGMENT_TESTS
 	);
-	assert_eq!(dst_mask, ash::vk::PipelineStageFlags::COMPUTE_SHADER);
+	assert_eq!(dst_mask, vk::PipelineStageFlags::COMPUTE_SHADER);
 	assert_eq!(
 		barrier.src_access_mask,
-		ash::vk::AccessFlags::DEPTH_STENCIL_ATTACHMENT_WRITE
+		vk::AccessFlags::DEPTH_STENCIL_ATTACHMENT_WRITE
 	);
-	assert_eq!(barrier.dst_access_mask, ash::vk::AccessFlags::SHADER_READ);
+	assert_eq!(barrier.dst_access_mask, vk::AccessFlags::SHADER_READ);
 	assert_eq!(
 		barrier.old_layout,
-		ash::vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL
+		vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL
 	);
 	assert_eq!(
 		barrier.new_layout,
-		ash::vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL
+		vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL
 	);
 }
 
@@ -135,9 +130,9 @@ fn graphics_write_depth_fragment_read_attachment() {
 		discard_contents: false,
 		src_queue_family_index: 0,
 		dst_queue_family_index: 0,
-		image: ash::vk::Image::null(),
-		range: ash::vk::ImageSubresourceRange {
-			aspect_mask: ash::vk::ImageAspectFlags::empty(),
+		image: vk::Image::null(),
+		range: vk::ImageSubresourceRange {
+			aspect_mask: vk::ImageAspectFlags::empty(),
 			base_mip_level: 0,
 			level_count: 1,
 			base_array_layer: 0,
@@ -149,25 +144,24 @@ fn graphics_write_depth_fragment_read_attachment() {
 
 	assert_eq!(
 		src_mask,
-		ash::vk::PipelineStageFlags::EARLY_FRAGMENT_TESTS
-			| ash::vk::PipelineStageFlags::LATE_FRAGMENT_TESTS
+		vk::PipelineStageFlags::EARLY_FRAGMENT_TESTS | vk::PipelineStageFlags::LATE_FRAGMENT_TESTS
 	);
-	assert_eq!(dst_mask, ash::vk::PipelineStageFlags::FRAGMENT_SHADER);
+	assert_eq!(dst_mask, vk::PipelineStageFlags::FRAGMENT_SHADER);
 	assert_eq!(
 		barrier.src_access_mask,
-		ash::vk::AccessFlags::DEPTH_STENCIL_ATTACHMENT_WRITE
+		vk::AccessFlags::DEPTH_STENCIL_ATTACHMENT_WRITE
 	);
 	assert_eq!(
 		barrier.dst_access_mask,
-		ash::vk::AccessFlags::INPUT_ATTACHMENT_READ
+		vk::AccessFlags::INPUT_ATTACHMENT_READ
 	);
 	assert_eq!(
 		barrier.old_layout,
-		ash::vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL
+		vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL
 	);
 	assert_eq!(
 		barrier.new_layout,
-		ash::vk::ImageLayout::DEPTH_STENCIL_READ_ONLY_OPTIMAL
+		vk::ImageLayout::DEPTH_STENCIL_READ_ONLY_OPTIMAL
 	);
 }
 
@@ -182,9 +176,9 @@ fn graphics_write_depth_fragment_read_sampled() {
 		discard_contents: false,
 		src_queue_family_index: 0,
 		dst_queue_family_index: 0,
-		image: ash::vk::Image::null(),
-		range: ash::vk::ImageSubresourceRange {
-			aspect_mask: ash::vk::ImageAspectFlags::empty(),
+		image: vk::Image::null(),
+		range: vk::ImageSubresourceRange {
+			aspect_mask: vk::ImageAspectFlags::empty(),
 			base_mip_level: 0,
 			level_count: 1,
 			base_array_layer: 0,
@@ -196,22 +190,21 @@ fn graphics_write_depth_fragment_read_sampled() {
 
 	assert_eq!(
 		src_mask,
-		ash::vk::PipelineStageFlags::EARLY_FRAGMENT_TESTS
-			| ash::vk::PipelineStageFlags::LATE_FRAGMENT_TESTS
+		vk::PipelineStageFlags::EARLY_FRAGMENT_TESTS | vk::PipelineStageFlags::LATE_FRAGMENT_TESTS
 	);
-	assert_eq!(dst_mask, ash::vk::PipelineStageFlags::FRAGMENT_SHADER);
+	assert_eq!(dst_mask, vk::PipelineStageFlags::FRAGMENT_SHADER);
 	assert_eq!(
 		barrier.src_access_mask,
-		ash::vk::AccessFlags::DEPTH_STENCIL_ATTACHMENT_WRITE
+		vk::AccessFlags::DEPTH_STENCIL_ATTACHMENT_WRITE
 	);
-	assert_eq!(barrier.dst_access_mask, ash::vk::AccessFlags::SHADER_READ);
+	assert_eq!(barrier.dst_access_mask, vk::AccessFlags::SHADER_READ);
 	assert_eq!(
 		barrier.old_layout,
-		ash::vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL
+		vk::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL
 	);
 	assert_eq!(
 		barrier.new_layout,
-		ash::vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL
+		vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL
 	);
 }
 
@@ -226,9 +219,9 @@ fn graphics_write_color_fragment_read_attachment() {
 		discard_contents: false,
 		src_queue_family_index: 0,
 		dst_queue_family_index: 0,
-		image: ash::vk::Image::null(),
-		range: ash::vk::ImageSubresourceRange {
-			aspect_mask: ash::vk::ImageAspectFlags::empty(),
+		image: vk::Image::null(),
+		range: vk::ImageSubresourceRange {
+			aspect_mask: vk::ImageAspectFlags::empty(),
 			base_mip_level: 0,
 			level_count: 1,
 			base_array_layer: 0,
@@ -238,26 +231,23 @@ fn graphics_write_color_fragment_read_attachment() {
 
 	let (src_mask, dst_mask, barrier) = vk_sync::get_image_memory_barrier(&image_barrier);
 
-	assert_eq!(
-		src_mask,
-		ash::vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT
-	);
-	assert_eq!(dst_mask, ash::vk::PipelineStageFlags::FRAGMENT_SHADER);
+	assert_eq!(src_mask, vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT);
+	assert_eq!(dst_mask, vk::PipelineStageFlags::FRAGMENT_SHADER);
 	assert_eq!(
 		barrier.src_access_mask,
-		ash::vk::AccessFlags::COLOR_ATTACHMENT_WRITE
+		vk::AccessFlags::COLOR_ATTACHMENT_WRITE
 	);
 	assert_eq!(
 		barrier.dst_access_mask,
-		ash::vk::AccessFlags::INPUT_ATTACHMENT_READ
+		vk::AccessFlags::INPUT_ATTACHMENT_READ
 	);
 	assert_eq!(
 		barrier.old_layout,
-		ash::vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL
+		vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL
 	);
 	assert_eq!(
 		barrier.new_layout,
-		ash::vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL
+		vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL
 	);
 }
 
@@ -272,9 +262,9 @@ fn graphics_write_color_fragment_read_sampled() {
 		discard_contents: false,
 		src_queue_family_index: 0,
 		dst_queue_family_index: 0,
-		image: ash::vk::Image::null(),
-		range: ash::vk::ImageSubresourceRange {
-			aspect_mask: ash::vk::ImageAspectFlags::empty(),
+		image: vk::Image::null(),
+		range: vk::ImageSubresourceRange {
+			aspect_mask: vk::ImageAspectFlags::empty(),
 			base_mip_level: 0,
 			level_count: 1,
 			base_array_layer: 0,
@@ -284,23 +274,20 @@ fn graphics_write_color_fragment_read_sampled() {
 
 	let (src_mask, dst_mask, barrier) = vk_sync::get_image_memory_barrier(&image_barrier);
 
-	assert_eq!(
-		src_mask,
-		ash::vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT
-	);
-	assert_eq!(dst_mask, ash::vk::PipelineStageFlags::FRAGMENT_SHADER);
+	assert_eq!(src_mask, vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT);
+	assert_eq!(dst_mask, vk::PipelineStageFlags::FRAGMENT_SHADER);
 	assert_eq!(
 		barrier.src_access_mask,
-		ash::vk::AccessFlags::COLOR_ATTACHMENT_WRITE
+		vk::AccessFlags::COLOR_ATTACHMENT_WRITE
 	);
-	assert_eq!(barrier.dst_access_mask, ash::vk::AccessFlags::SHADER_READ);
+	assert_eq!(barrier.dst_access_mask, vk::AccessFlags::SHADER_READ);
 	assert_eq!(
 		barrier.old_layout,
-		ash::vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL
+		vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL
 	);
 	assert_eq!(
 		barrier.new_layout,
-		ash::vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL
+		vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL
 	);
 }
 
@@ -315,9 +302,9 @@ fn graphics_write_color_vertex_read_sampled() {
 		discard_contents: false,
 		src_queue_family_index: 0,
 		dst_queue_family_index: 0,
-		image: ash::vk::Image::null(),
-		range: ash::vk::ImageSubresourceRange {
-			aspect_mask: ash::vk::ImageAspectFlags::empty(),
+		image: vk::Image::null(),
+		range: vk::ImageSubresourceRange {
+			aspect_mask: vk::ImageAspectFlags::empty(),
 			base_mip_level: 0,
 			level_count: 1,
 			base_array_layer: 0,
@@ -327,23 +314,20 @@ fn graphics_write_color_vertex_read_sampled() {
 
 	let (src_mask, dst_mask, barrier) = vk_sync::get_image_memory_barrier(&image_barrier);
 
-	assert_eq!(
-		src_mask,
-		ash::vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT
-	);
-	assert_eq!(dst_mask, ash::vk::PipelineStageFlags::VERTEX_SHADER);
+	assert_eq!(src_mask, vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT);
+	assert_eq!(dst_mask, vk::PipelineStageFlags::VERTEX_SHADER);
 	assert_eq!(
 		barrier.src_access_mask,
-		ash::vk::AccessFlags::COLOR_ATTACHMENT_WRITE
+		vk::AccessFlags::COLOR_ATTACHMENT_WRITE
 	);
-	assert_eq!(barrier.dst_access_mask, ash::vk::AccessFlags::SHADER_READ);
+	assert_eq!(barrier.dst_access_mask, vk::AccessFlags::SHADER_READ);
 	assert_eq!(
 		barrier.old_layout,
-		ash::vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL
+		vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL
 	);
 	assert_eq!(
 		barrier.new_layout,
-		ash::vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL
+		vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL
 	);
 }
 
@@ -360,9 +344,9 @@ fn graphics_read_sampled_graphics_write_color() {
 		discard_contents: false,
 		src_queue_family_index: 0,
 		dst_queue_family_index: 0,
-		image: ash::vk::Image::null(),
-		range: ash::vk::ImageSubresourceRange {
-			aspect_mask: ash::vk::ImageAspectFlags::empty(),
+		image: vk::Image::null(),
+		range: vk::ImageSubresourceRange {
+			aspect_mask: vk::ImageAspectFlags::empty(),
 			base_mip_level: 0,
 			level_count: 1,
 			base_array_layer: 0,
@@ -372,20 +356,17 @@ fn graphics_read_sampled_graphics_write_color() {
 
 	let (src_mask, dst_mask, barrier) = vk_sync::get_image_memory_barrier(&image_barrier);
 
-	assert_eq!(src_mask, ash::vk::PipelineStageFlags::FRAGMENT_SHADER);
-	assert_eq!(
-		dst_mask,
-		ash::vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT
-	);
-	assert_eq!(barrier.src_access_mask, ash::vk::AccessFlags::empty());
-	assert_eq!(barrier.dst_access_mask, ash::vk::AccessFlags::empty());
+	assert_eq!(src_mask, vk::PipelineStageFlags::FRAGMENT_SHADER);
+	assert_eq!(dst_mask, vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT);
+	assert_eq!(barrier.src_access_mask, vk::AccessFlags::empty());
+	assert_eq!(barrier.dst_access_mask, vk::AccessFlags::empty());
 	assert_eq!(
 		barrier.old_layout,
-		ash::vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL
+		vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL
 	);
 	assert_eq!(
 		barrier.new_layout,
-		ash::vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL
+		vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL
 	);
 }
 
@@ -400,9 +381,9 @@ fn transfer_write_image_fragment_read_sampled() {
 		discard_contents: false,
 		src_queue_family_index: 0,
 		dst_queue_family_index: 0,
-		image: ash::vk::Image::null(),
-		range: ash::vk::ImageSubresourceRange {
-			aspect_mask: ash::vk::ImageAspectFlags::empty(),
+		image: vk::Image::null(),
+		range: vk::ImageSubresourceRange {
+			aspect_mask: vk::ImageAspectFlags::empty(),
 			base_mip_level: 0,
 			level_count: 1,
 			base_array_layer: 0,
@@ -412,20 +393,14 @@ fn transfer_write_image_fragment_read_sampled() {
 
 	let (src_mask, dst_mask, barrier) = vk_sync::get_image_memory_barrier(&image_barrier);
 
-	assert_eq!(src_mask, ash::vk::PipelineStageFlags::TRANSFER);
-	assert_eq!(dst_mask, ash::vk::PipelineStageFlags::FRAGMENT_SHADER);
-	assert_eq!(
-		barrier.src_access_mask,
-		ash::vk::AccessFlags::TRANSFER_WRITE
-	);
-	assert_eq!(barrier.dst_access_mask, ash::vk::AccessFlags::SHADER_READ);
-	assert_eq!(
-		barrier.old_layout,
-		ash::vk::ImageLayout::TRANSFER_DST_OPTIMAL
-	);
+	assert_eq!(src_mask, vk::PipelineStageFlags::TRANSFER);
+	assert_eq!(dst_mask, vk::PipelineStageFlags::FRAGMENT_SHADER);
+	assert_eq!(barrier.src_access_mask, vk::AccessFlags::TRANSFER_WRITE);
+	assert_eq!(barrier.dst_access_mask, vk::AccessFlags::SHADER_READ);
+	assert_eq!(barrier.old_layout, vk::ImageLayout::TRANSFER_DST_OPTIMAL);
 	assert_eq!(
 		barrier.new_layout,
-		ash::vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL
+		vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL
 	);
 }
 
@@ -440,9 +415,9 @@ fn graphics_write_color_presentation() {
 		discard_contents: false,
 		src_queue_family_index: 0,
 		dst_queue_family_index: 0,
-		image: ash::vk::Image::null(),
-		range: ash::vk::ImageSubresourceRange {
-			aspect_mask: ash::vk::ImageAspectFlags::empty(),
+		image: vk::Image::null(),
+		range: vk::ImageSubresourceRange {
+			aspect_mask: vk::ImageAspectFlags::empty(),
 			base_mip_level: 0,
 			level_count: 1,
 			base_array_layer: 0,
@@ -452,19 +427,16 @@ fn graphics_write_color_presentation() {
 
 	let (src_mask, dst_mask, barrier) = vk_sync::get_image_memory_barrier(&image_barrier);
 
-	assert_eq!(
-		src_mask,
-		ash::vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT
-	);
-	assert_eq!(dst_mask, ash::vk::PipelineStageFlags::BOTTOM_OF_PIPE);
+	assert_eq!(src_mask, vk::PipelineStageFlags::COLOR_ATTACHMENT_OUTPUT);
+	assert_eq!(dst_mask, vk::PipelineStageFlags::BOTTOM_OF_PIPE);
 	assert_eq!(
 		barrier.src_access_mask,
-		ash::vk::AccessFlags::COLOR_ATTACHMENT_WRITE
+		vk::AccessFlags::COLOR_ATTACHMENT_WRITE
 	);
-	assert_eq!(barrier.dst_access_mask, ash::vk::AccessFlags::empty());
+	assert_eq!(barrier.dst_access_mask, vk::AccessFlags::empty());
 	assert_eq!(
 		barrier.old_layout,
-		ash::vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL
+		vk::ImageLayout::COLOR_ATTACHMENT_OPTIMAL
 	);
-	assert_eq!(barrier.new_layout, ash::vk::ImageLayout::PRESENT_SRC_KHR);
+	assert_eq!(barrier.new_layout, vk::ImageLayout::PRESENT_SRC_KHR);
 }


### PR DESCRIPTION
This crate seems neat and it'd be great to be able to use it with the current version of ash. Apart from changing the version of ash being used, I've also changed the functions in `cmd` to take an `&ash::Device` as input, as well as using `vk::X` instead of `ash::vk::X` for structs as I personally prefer it.

With thanks to @MaikKlein and @h3r2tic.