### PR TITLE
Upgrade to Ash 0.38

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,4 @@ appveyor = { repository = "gwihlidal/vk-sync-rs" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-ash = "0.33"
+ash = "0.38"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
     ".gitignore",
     "appveyor.yml"
 ]
-edition = "2018"
+edition = "2024"
 
 [badges]
 travis-ci = { repository = "gwihlidal/vk-sync-rs" }

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -151,7 +151,7 @@ pub fn wait_events(
 	unsafe {
 		device.cmd_wait_events(
 			command_buffer,
-			&events,
+			events,
 			src_stage_mask,
 			dst_stage_mask,
 			&vk_memory_barriers,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -306,12 +306,12 @@ pub struct ImageBarrier<'a> {
 /// Mapping function that translates a global barrier into a set of source and
 /// destination pipeline stages, and a memory barrier, that can be used with
 /// Vulkan synchronization methods.
-pub fn get_memory_barrier(
-	barrier: &GlobalBarrier,
+pub fn get_memory_barrier<'a>(
+	barrier: &GlobalBarrier<'a>,
 ) -> (
 	vk::PipelineStageFlags,
 	vk::PipelineStageFlags,
-	vk::MemoryBarrier,
+	vk::MemoryBarrier<'a>,
 ) {
 	let mut src_stages = vk::PipelineStageFlags::empty();
 	let mut dst_stages = vk::PipelineStageFlags::empty();
@@ -357,12 +357,12 @@ pub fn get_memory_barrier(
 /// Mapping function that translates a buffer barrier into a set of source and
 /// destination pipeline stages, and a buffer memory barrier, that can be used
 /// with Vulkan synchronization methods.
-pub fn get_buffer_memory_barrier(
-	barrier: &BufferBarrier,
+pub fn get_buffer_memory_barrier<'a>(
+	barrier: &BufferBarrier<'a>,
 ) -> (
 	vk::PipelineStageFlags,
 	vk::PipelineStageFlags,
-	vk::BufferMemoryBarrier,
+	vk::BufferMemoryBarrier<'a>,
 ) {
 	let mut src_stages = vk::PipelineStageFlags::empty();
 	let mut dst_stages = vk::PipelineStageFlags::empty();
@@ -415,12 +415,12 @@ pub fn get_buffer_memory_barrier(
 /// Mapping function that translates an image barrier into a set of source and
 /// destination pipeline stages, and an image memory barrier, that can be used
 /// with Vulkan synchronization methods.
-pub fn get_image_memory_barrier(
-	barrier: &ImageBarrier,
+pub fn get_image_memory_barrier<'a>(
+	barrier: &ImageBarrier<'a>,
 ) -> (
 	vk::PipelineStageFlags,
 	vk::PipelineStageFlags,
-	vk::ImageMemoryBarrier,
+	vk::ImageMemoryBarrier<'a>,
 ) {
 	let mut src_stages = vk::PipelineStageFlags::empty();
 	let mut dst_stages = vk::PipelineStageFlags::empty();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,9 +18,10 @@ use ash::vk;
 pub mod cmd;
 
 /// Defines all potential resource usages
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Default)]
 pub enum AccessType {
 	/// No access. Useful primarily for initialization
+	#[default]
 	Nothing,
 
 	/// Command buffer read operation as defined by `NVX_device_generated_commands`
@@ -197,19 +198,14 @@ pub enum AccessType {
 	AccelerationStructureBufferWrite,
 }
 
-impl Default for AccessType {
-	fn default() -> Self {
-		AccessType::Nothing
-	}
-}
-
 /// Defines a handful of layout options for images.
 /// Rather than a list of all possible image layouts, this reduced list is
 /// correlated with the access types to map to the correct Vulkan layouts.
 /// `Optimal` is usually preferred.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Default)]
 pub enum ImageLayout {
 	/// Choose the most optimal layout for each usage. Performs layout transitions as appropriate for the access.
+	#[default]
 	Optimal,
 
 	/// Layout accessible by all Vulkan access types on a device - no layout transitions except for presentation
@@ -219,12 +215,6 @@ pub enum ImageLayout {
 	/// Requires `VK_KHR_shared_presentable_image` to be enabled, and this can only be used for shared presentable
 	/// images (i.e. single-buffered swap chains).
 	GeneralAndPresentation,
-}
-
-impl Default for ImageLayout {
-	fn default() -> Self {
-		ImageLayout::Optimal
-	}
 }
 
 /// Global barriers define a set of accesses on multiple resources at once.
@@ -818,23 +808,23 @@ pub(crate) fn get_access_info(access_type: AccessType) -> AccessInfo {
 }
 
 pub(crate) fn is_write_access(access_type: AccessType) -> bool {
-	match access_type {
-		AccessType::CommandBufferWriteNVX => true,
-		AccessType::VertexShaderWrite => true,
-		AccessType::TessellationControlShaderWrite => true,
-		AccessType::TessellationEvaluationShaderWrite => true,
-		AccessType::GeometryShaderWrite => true,
-		AccessType::FragmentShaderWrite => true,
-		AccessType::ColorAttachmentWrite => true,
-		AccessType::DepthStencilAttachmentWrite => true,
-		AccessType::DepthAttachmentWriteStencilReadOnly => true,
-		AccessType::StencilAttachmentWriteDepthReadOnly => true,
-		AccessType::ComputeShaderWrite => true,
-		AccessType::AnyShaderWrite => true,
-		AccessType::TransferWrite => true,
-		AccessType::HostWrite => true,
-		AccessType::ColorAttachmentReadWrite => true,
-		AccessType::General => true,
-		_ => false,
-	}
+	matches!(
+		access_type,
+		AccessType::CommandBufferWriteNVX
+			| AccessType::VertexShaderWrite
+			| AccessType::TessellationControlShaderWrite
+			| AccessType::TessellationEvaluationShaderWrite
+			| AccessType::GeometryShaderWrite
+			| AccessType::FragmentShaderWrite
+			| AccessType::ColorAttachmentWrite
+			| AccessType::DepthStencilAttachmentWrite
+			| AccessType::DepthAttachmentWriteStencilReadOnly
+			| AccessType::StencilAttachmentWriteDepthReadOnly
+			| AccessType::ComputeShaderWrite
+			| AccessType::AnyShaderWrite
+			| AccessType::TransferWrite
+			| AccessType::HostWrite
+			| AccessType::ColorAttachmentReadWrite
+			| AccessType::General
+	)
 }


### PR DESCRIPTION
Thanks for the great little library.

In ash 0.38, the Vulkan memory barrier structures (`MemoryBarrier`, `BufferMemoryBarrier`, `ImageMemoryBarrier`) were updated to include lifetime parameters to support the new `push_next()` functionality for extension chaining. This required updating the library's API to properly handle these lifetimes.

Bumped to Rust 2024 edition -- no changes.

Fixed a few clippy warnings.